### PR TITLE
Bugfixes, tests and QOL changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,4 @@ go.work.sum
 dist/
 temp/
 
-e2e/__debug*
-e2e/assets/__debug*
+__debug*

--- a/definitions/types.go
+++ b/definitions/types.go
@@ -1,6 +1,8 @@
 package definitions
 
 import (
+	"go/types"
+
 	"github.com/gopher-fleece/runtime"
 )
 
@@ -381,3 +383,9 @@ const (
 	AstNodeKindParenthesis AstNodeKind = "Parenthesis"
 	AstNodeKindAlias       AstNodeKind = "Alias"
 )
+
+type Iterable interface {
+	Elem() types.Type
+	Underlying() types.Type
+	String() string
+}

--- a/extractor/visitors/controller/auxiliary.go
+++ b/extractor/visitors/controller/auxiliary.go
@@ -35,6 +35,11 @@ func (v ControllerVisitor) isAnErrorEmbeddingType(meta definitions.TypeMetadata)
 		return true, nil
 	}
 
+	// Universe types are leaf nodes and can never embed anything- no reason to check them
+	if meta.IsUniverseType {
+		return false, nil
+	}
+
 	pkg := extractor.FilterPackageByFullName(v.packagesFacade.GetAllPackages(), meta.FullyQualifiedPackage)
 	embeds, err := extractor.DoesStructEmbedType(pkg, meta.Name, "", "error")
 	if err != nil {

--- a/extractor/visitors/controller/public.go
+++ b/extractor/visitors/controller/public.go
@@ -142,9 +142,21 @@ func (v *ControllerVisitor) GetModelsFlat() (*definitions.Models, bool, error) {
 		}
 	}
 
+	structs := typeVisitor.GetStructs()
+	enums := typeVisitor.GetEnums()
+
+	slices.SortFunc(structs, func(a, b definitions.StructMetadata) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+
+	slices.SortFunc(enums, func(a, b definitions.EnumMetadata) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+
 	flatModels := &definitions.Models{
-		Structs: typeVisitor.GetStructs(),
-		Enums:   typeVisitor.GetEnums(),
+		Structs: structs,
+		Enums:   enums,
 	}
+
 	return flatModels, hasAnyErrorTypes, nil
 }

--- a/extractor/visitors/type.visitor.go
+++ b/extractor/visitors/type.visitor.go
@@ -94,11 +94,16 @@ func (v *TypeVisitor) VisitStruct(fullPackageName string, structName string, str
 		case *types.Pointer:
 			// Raise error for pointer fields.
 			return fmt.Errorf("field %q in struct %q is a pointer, which is not allowed", field.Name(), structName)
-		case *types.Array, *types.Slice:
-			// For iterables, get the underlying field type.
-			//
-			// NOTE: Need to verify this works for complex array types
+		case *types.Slice:
+		case *types.Array:
+			// Field type string is for the parent model's metadata
 			fieldTypeString = extractor.GetIterableElementType(t)
+
+			// Dive into the slice and recurse into nested structs, if required
+			err := v.processIterableField(field, t, fieldTypeString, &structInfo, tag)
+			if err != nil {
+				return err
+			}
 		case *types.Named:
 			isEnumOrAlias, err := v.processNamedEntity(t, &structInfo, tag)
 			if err != nil {
@@ -127,12 +132,56 @@ func (v *TypeVisitor) VisitStruct(fullPackageName string, structName string, str
 			fieldMeta.Description = fieldAttr.GetDescription()
 			deprecationOpts := getDeprecationOpts(*fieldAttr)
 			fieldMeta.Deprecation = &deprecationOpts
+		} else {
+			fieldMeta.Deprecation = &definitions.DeprecationOptions{}
 		}
 
 		structInfo.Fields = append(structInfo.Fields, fieldMeta)
 	}
 
 	v.structsByName[fullStructName] = &structInfo
+	return nil
+}
+
+func (v *TypeVisitor) processIterableField(
+	field *types.Var,
+	fieldType definitions.Iterable,
+	sliceElementTypeNameString string,
+	structInfo *definitions.StructMetadata,
+	fieldTag string,
+) error {
+	if extractor.IsBasic(fieldType) {
+		return nil
+	}
+
+	pkg := extractor.GetPackageOwnerOfType(fieldType)
+	if pkg == nil {
+		baseTypeName := sliceElementTypeNameString
+		if strings.HasPrefix(sliceElementTypeNameString, "[]") {
+			baseTypeName = sliceElementTypeNameString[2:]
+		}
+
+		if extractor.IsUniverseType(baseTypeName) {
+			// If there's no owner package, this might be a universe type. If so, just ignore it
+			return nil
+		}
+
+		// Otherwise, we've a problem.
+		return fmt.Errorf(
+			"could not deduce package for the type of field %s of type %s on struct %s",
+			field.Name(),
+			sliceElementTypeNameString,
+			structInfo.Name,
+		)
+	}
+
+	if named, ok := fieldType.Elem().(*types.Named); ok {
+		_, err := v.processNamedEntity(named, structInfo, fieldTag)
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/extractor/visitors/type.visitor.go
+++ b/extractor/visitors/type.visitor.go
@@ -95,6 +95,16 @@ func (v *TypeVisitor) VisitStruct(fullPackageName string, structName string, str
 			// Raise error for pointer fields.
 			return fmt.Errorf("field %q in struct %q is a pointer, which is not allowed", field.Name(), structName)
 		case *types.Slice:
+			// Go's rigid typing makes reuse pretty difficult...
+
+			// Field type string is for the parent model's metadata
+			fieldTypeString = extractor.GetIterableElementType(t)
+
+			// Dive into the slice and recurse into nested structs, if required
+			err := v.processIterableField(field, t, fieldTypeString, &structInfo, tag)
+			if err != nil {
+				return err
+			}
 		case *types.Array:
 			// Field type string is for the parent model's metadata
 			fieldTypeString = extractor.GetIterableElementType(t)

--- a/test/sanity/sanity.controller.go
+++ b/test/sanity/sanity.controller.go
@@ -1,6 +1,7 @@
 package sanity_test
 
 import (
+	"github.com/gopher-fleece/gleece/test/units"
 	"github.com/gopher-fleece/runtime"
 )
 
@@ -33,4 +34,11 @@ func (ec *SanityController) ValidMethodWithSimpleRouteQueryAndHeaderParameters(
 	headerParam float32,
 ) (SimpleResponseModel, error) {
 	return SimpleResponseModel{}, nil
+}
+
+// @Method(POST)
+// @Route(/imports-from-other-package)
+// @Body(body)
+func (ec *SanityController) ImportsTypeFromOtherPackage(body []units.StructWithStructSlice) error {
+	return nil
 }

--- a/test/sanity/sanity_test.go
+++ b/test/sanity/sanity_test.go
@@ -27,7 +27,7 @@ var _ = Describe("Sanity Controller", func() {
 		Expect(metadata).ToNot(BeNil())
 		Expect(metadata).To(HaveLen(1))
 		Expect(models).ToNot(BeNil())
-		Expect(models).To(HaveLen(1))
+		Expect(models).To(HaveLen(3))
 		Expect(schemaShouldHaveStdErrorSanity).To(BeTrue())
 	})
 
@@ -39,7 +39,7 @@ var _ = Describe("Sanity Controller", func() {
 		Expect(controllerMeta.Tag).To(Equal("Sanity Controller Tag"))
 		Expect(controllerMeta.RestMetadata.Path).To(Equal("/test/sanity"))
 		Expect(controllerMeta.Description).To(Equal("Sanity Controller"))
-		Expect(controllerMeta.Routes).To(HaveLen(1))
+		Expect(controllerMeta.Routes).To(HaveLen(2))
 		Expect(controllerMeta.Security).To(HaveLen(1))
 		Expect(controllerMeta.Security[0].SecurityAnnotation).To(HaveLen(1))
 		Expect(controllerMeta.Security[0].SecurityAnnotation[0].SchemaName).To(Equal("sanitySchema"))
@@ -154,18 +154,61 @@ var _ = Describe("Sanity Controller", func() {
 	})
 
 	It("Produces correct models list", func() {
-		Expect(models[0].Name).To(Equal("SimpleResponseModel"))
-		Expect(models[0].FullyQualifiedPackage).To(Equal("github.com/gopher-fleece/gleece/test/sanity"))
-		Expect(models[0].Description).To(Equal("This should be the actual description"))
-		Expect(models[0].Fields).To(HaveLen(1))
-		Expect(models[0].Fields[0].Name).To(Equal("SomeValue"))
-		Expect(models[0].Fields[0].Type).To(Equal("int"))
-		Expect(models[0].Fields[0].Description).To(Equal("A description for the value"))
-		Expect(models[0].Fields[0].Tag).To(Equal("validate:\"required,min=0,max=10\""))
-		Expect(models[0].Fields[0].Deprecation.Deprecated).To(BeFalse())
-		Expect(models[0].Fields[0].Deprecation.Description).To(Equal(""))
-		Expect(models[0].Deprecation.Deprecated).To(BeFalse())
-		Expect(models[0].Deprecation.Description).To(Equal(""))
+		// Model 1
+		model1 := models[0]
+		Expect(model1.Name).To(Equal("SimpleResponseModel"))
+		Expect(model1.FullyQualifiedPackage).To(Equal("github.com/gopher-fleece/gleece/test/sanity"))
+		Expect(model1.Description).To(Equal("This should be the actual description"))
+		Expect(model1.Fields).To(HaveLen(1))
+		Expect(model1.Fields[0].Name).To(Equal("SomeValue"))
+		Expect(model1.Fields[0].Type).To(Equal("int"))
+		Expect(model1.Fields[0].Description).To(Equal("A description for the value"))
+		Expect(model1.Fields[0].Tag).To(Equal("validate:\"required,min=0,max=10\""))
+		Expect(model1.Fields[0].Deprecation.Deprecated).To(BeFalse())
+		Expect(model1.Fields[0].Deprecation.Description).To(Equal(""))
+		Expect(model1.Deprecation.Deprecated).To(BeFalse())
+		Expect(model1.Deprecation.Description).To(Equal(""))
+
+		// Model 2
+		model2 := models[1]
+		Expect(model2.Name).To(Equal("SimpleStruct"))
+		Expect(model2.FullyQualifiedPackage).To(Equal("github.com/gopher-fleece/gleece/test/units"))
+		Expect(model2.Description).To(BeEmpty())
+
+		Expect(model2.Fields).To(HaveLen(2))
+		Expect(model2.Fields[0].Name).To(Equal("FieldA"))
+		Expect(model2.Fields[0].Type).To(Equal("string"))
+		Expect(model2.Fields[0].Description).To(BeEmpty())
+		Expect(model2.Fields[0].Tag).To(BeEmpty())
+		Expect(model2.Fields[0].Deprecation.Deprecated).To(BeFalse())
+		Expect(model2.Fields[0].Deprecation.Description).To(Equal(""))
+
+		Expect(model2.Fields[1].Name).To(Equal("FieldB"))
+		Expect(model2.Fields[1].Type).To(Equal("int"))
+		Expect(model2.Fields[1].Description).To(BeEmpty())
+		Expect(model2.Fields[1].Tag).To(BeEmpty())
+		Expect(model2.Fields[1].Deprecation.Deprecated).To(BeFalse())
+		Expect(model2.Fields[1].Deprecation.Description).To(Equal(""))
+
+		Expect(model2.Deprecation.Deprecated).To(BeFalse())
+		Expect(model2.Deprecation.Description).To(Equal(""))
+
+		// Model 3
+		model3 := models[2]
+		Expect(model3.Name).To(Equal("StructWithStructSlice"))
+		Expect(model3.FullyQualifiedPackage).To(Equal("github.com/gopher-fleece/gleece/test/units"))
+		Expect(model3.Description).To(BeEmpty())
+
+		Expect(model3.Fields).To(HaveLen(1))
+		Expect(model3.Fields[0].Name).To(Equal("SimpleStructSlice"))
+		Expect(model3.Fields[0].Type).To(Equal("[]SimpleStruct"))
+		Expect(model3.Fields[0].Description).To(BeEmpty())
+		Expect(model3.Fields[0].Tag).To(BeEmpty())
+		Expect(model3.Fields[0].Deprecation.Deprecated).To(BeFalse())
+		Expect(model3.Fields[0].Deprecation.Description).To(Equal(""))
+
+		Expect(model3.Deprecation.Deprecated).To(BeFalse())
+		Expect(model3.Deprecation.Description).To(Equal(""))
 	})
 })
 

--- a/test/units/aux.types.go
+++ b/test/units/aux.types.go
@@ -44,3 +44,12 @@ type StructWithReceivers struct{}
 
 func (s StructWithReceivers) ValueReceiverForStructWithReceivers()    {}
 func (s *StructWithReceivers) PointerReceiverForStructWithReceivers() {}
+
+type SimpleStruct struct {
+	FieldA string
+	FieldB int
+}
+
+type StructWithStructSlice struct {
+	SimpleStructSlice []SimpleStruct
+}

--- a/test/visitors/configs/receiver.with.invalid.json.json
+++ b/test/visitors/configs/receiver.with.invalid.json.json
@@ -1,0 +1,54 @@
+{
+	"commonConfig": {
+		"controllerGlobs": [
+			"./controllers/receiver.with.invalid.json.go"
+		]
+	},
+	"routesConfig": {
+		"engine": "gin",
+		"outputPath": "./dist/gleece.go",
+		"outputFilePerms": "0644",
+		"authorizationConfig": {
+			"authFileFullPackageName": "github.com/gopher-fleece/gleece/test/fixtures",
+			"enforceSecurityOnAllRoutes": true
+		}
+	},
+	"openapiGeneratorConfig": {
+		"openapi": "3.0.0",
+		"info": {
+			"title": "Sample API",
+			"description": "This is a sample API",
+			"termsOfService": "http://example.com/terms/",
+			"contact": {
+				"name": "API Support",
+				"url": "http://www.example.com/support",
+				"email": "support@example.com"
+			},
+			"license": {
+				"name": "Apache 2.0",
+				"url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+			},
+			"version": "1.0.0"
+		},
+		"baseUrl": "https://api.example.com",
+		"securitySchemes": [
+			{
+				"description": "API Key for accessing the API",
+				"name": "securitySchemaName",
+				"fieldName": "x-header-name",
+				"type": "apiKey",
+				"in": "header"
+			}
+		],
+		"defaultSecurity": {
+			"name": "sanitySchema",
+			"scopes": [
+				"read",
+				"write"
+			]
+		},
+		"specGeneratorConfig": {
+			"outputPath": "./dist/swagger.json"
+		}
+	}
+}

--- a/test/visitors/configs/receiver.with.no.comments.json
+++ b/test/visitors/configs/receiver.with.no.comments.json
@@ -1,0 +1,54 @@
+{
+	"commonConfig": {
+		"controllerGlobs": [
+			"./controllers/receiver.with.no.comments.go"
+		]
+	},
+	"routesConfig": {
+		"engine": "gin",
+		"outputPath": "./dist/gleece.go",
+		"outputFilePerms": "0644",
+		"authorizationConfig": {
+			"authFileFullPackageName": "github.com/gopher-fleece/gleece/test/fixtures",
+			"enforceSecurityOnAllRoutes": true
+		}
+	},
+	"openapiGeneratorConfig": {
+		"openapi": "3.0.0",
+		"info": {
+			"title": "Sample API",
+			"description": "This is a sample API",
+			"termsOfService": "http://example.com/terms/",
+			"contact": {
+				"name": "API Support",
+				"url": "http://www.example.com/support",
+				"email": "support@example.com"
+			},
+			"license": {
+				"name": "Apache 2.0",
+				"url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+			},
+			"version": "1.0.0"
+		},
+		"baseUrl": "https://api.example.com",
+		"securitySchemes": [
+			{
+				"description": "API Key for accessing the API",
+				"name": "securitySchemaName",
+				"fieldName": "x-header-name",
+				"type": "apiKey",
+				"in": "header"
+			}
+		],
+		"defaultSecurity": {
+			"name": "sanitySchema",
+			"scopes": [
+				"read",
+				"write"
+			]
+		},
+		"specGeneratorConfig": {
+			"outputPath": "./dist/swagger.json"
+		}
+	}
+}

--- a/test/visitors/configs/receiver.with.no.method.annotation.json
+++ b/test/visitors/configs/receiver.with.no.method.annotation.json
@@ -1,0 +1,54 @@
+{
+	"commonConfig": {
+		"controllerGlobs": [
+			"./controllers/receiver.with.no.method.annotation.go"
+		]
+	},
+	"routesConfig": {
+		"engine": "gin",
+		"outputPath": "./dist/gleece.go",
+		"outputFilePerms": "0644",
+		"authorizationConfig": {
+			"authFileFullPackageName": "github.com/gopher-fleece/gleece/test/fixtures",
+			"enforceSecurityOnAllRoutes": true
+		}
+	},
+	"openapiGeneratorConfig": {
+		"openapi": "3.0.0",
+		"info": {
+			"title": "Sample API",
+			"description": "This is a sample API",
+			"termsOfService": "http://example.com/terms/",
+			"contact": {
+				"name": "API Support",
+				"url": "http://www.example.com/support",
+				"email": "support@example.com"
+			},
+			"license": {
+				"name": "Apache 2.0",
+				"url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+			},
+			"version": "1.0.0"
+		},
+		"baseUrl": "https://api.example.com",
+		"securitySchemes": [
+			{
+				"description": "API Key for accessing the API",
+				"name": "securitySchemaName",
+				"fieldName": "x-header-name",
+				"type": "apiKey",
+				"in": "header"
+			}
+		],
+		"defaultSecurity": {
+			"name": "sanitySchema",
+			"scopes": [
+				"read",
+				"write"
+			]
+		},
+		"specGeneratorConfig": {
+			"outputPath": "./dist/swagger.json"
+		}
+	}
+}

--- a/test/visitors/configs/receiver.with.no.route.annotation.json
+++ b/test/visitors/configs/receiver.with.no.route.annotation.json
@@ -1,0 +1,54 @@
+{
+	"commonConfig": {
+		"controllerGlobs": [
+			"./controllers/receiver.with.no.route.annotation.go"
+		]
+	},
+	"routesConfig": {
+		"engine": "gin",
+		"outputPath": "./dist/gleece.go",
+		"outputFilePerms": "0644",
+		"authorizationConfig": {
+			"authFileFullPackageName": "github.com/gopher-fleece/gleece/test/fixtures",
+			"enforceSecurityOnAllRoutes": true
+		}
+	},
+	"openapiGeneratorConfig": {
+		"openapi": "3.0.0",
+		"info": {
+			"title": "Sample API",
+			"description": "This is a sample API",
+			"termsOfService": "http://example.com/terms/",
+			"contact": {
+				"name": "API Support",
+				"url": "http://www.example.com/support",
+				"email": "support@example.com"
+			},
+			"license": {
+				"name": "Apache 2.0",
+				"url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+			},
+			"version": "1.0.0"
+		},
+		"baseUrl": "https://api.example.com",
+		"securitySchemes": [
+			{
+				"description": "API Key for accessing the API",
+				"name": "securitySchemaName",
+				"fieldName": "x-header-name",
+				"type": "apiKey",
+				"in": "header"
+			}
+		],
+		"defaultSecurity": {
+			"name": "sanitySchema",
+			"scopes": [
+				"read",
+				"write"
+			]
+		},
+		"specGeneratorConfig": {
+			"outputPath": "./dist/swagger.json"
+		}
+	}
+}

--- a/test/visitors/configs/receiver.with.non.error.return.json
+++ b/test/visitors/configs/receiver.with.non.error.return.json
@@ -1,0 +1,54 @@
+{
+	"commonConfig": {
+		"controllerGlobs": [
+			"./controllers/receiver.with.non.error.return.go"
+		]
+	},
+	"routesConfig": {
+		"engine": "gin",
+		"outputPath": "./dist/gleece.go",
+		"outputFilePerms": "0644",
+		"authorizationConfig": {
+			"authFileFullPackageName": "github.com/gopher-fleece/gleece/test/fixtures",
+			"enforceSecurityOnAllRoutes": true
+		}
+	},
+	"openapiGeneratorConfig": {
+		"openapi": "3.0.0",
+		"info": {
+			"title": "Sample API",
+			"description": "This is a sample API",
+			"termsOfService": "http://example.com/terms/",
+			"contact": {
+				"name": "API Support",
+				"url": "http://www.example.com/support",
+				"email": "support@example.com"
+			},
+			"license": {
+				"name": "Apache 2.0",
+				"url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+			},
+			"version": "1.0.0"
+		},
+		"baseUrl": "https://api.example.com",
+		"securitySchemes": [
+			{
+				"description": "API Key for accessing the API",
+				"name": "securitySchemaName",
+				"fieldName": "x-header-name",
+				"type": "apiKey",
+				"in": "header"
+			}
+		],
+		"defaultSecurity": {
+			"name": "sanitySchema",
+			"scopes": [
+				"read",
+				"write"
+			]
+		},
+		"specGeneratorConfig": {
+			"outputPath": "./dist/swagger.json"
+		}
+	}
+}

--- a/test/visitors/configs/receiver.with.void.return.json
+++ b/test/visitors/configs/receiver.with.void.return.json
@@ -1,0 +1,54 @@
+{
+	"commonConfig": {
+		"controllerGlobs": [
+			"./controllers/receiver.with.void.return.go"
+		]
+	},
+	"routesConfig": {
+		"engine": "gin",
+		"outputPath": "./dist/gleece.go",
+		"outputFilePerms": "0644",
+		"authorizationConfig": {
+			"authFileFullPackageName": "github.com/gopher-fleece/gleece/test/fixtures",
+			"enforceSecurityOnAllRoutes": true
+		}
+	},
+	"openapiGeneratorConfig": {
+		"openapi": "3.0.0",
+		"info": {
+			"title": "Sample API",
+			"description": "This is a sample API",
+			"termsOfService": "http://example.com/terms/",
+			"contact": {
+				"name": "API Support",
+				"url": "http://www.example.com/support",
+				"email": "support@example.com"
+			},
+			"license": {
+				"name": "Apache 2.0",
+				"url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+			},
+			"version": "1.0.0"
+		},
+		"baseUrl": "https://api.example.com",
+		"securitySchemes": [
+			{
+				"description": "API Key for accessing the API",
+				"name": "securitySchemaName",
+				"fieldName": "x-header-name",
+				"type": "apiKey",
+				"in": "header"
+			}
+		],
+		"defaultSecurity": {
+			"name": "sanitySchema",
+			"scopes": [
+				"read",
+				"write"
+			]
+		},
+		"specGeneratorConfig": {
+			"outputPath": "./dist/swagger.json"
+		}
+	}
+}

--- a/test/visitors/controllers/receiver.with.invalid.json.go
+++ b/test/visitors/controllers/receiver.with.invalid.json.go
@@ -1,0 +1,17 @@
+package visitors_test
+
+import (
+	"github.com/gopher-fleece/runtime"
+)
+
+// @Tag(Receiver With Invalid Json)
+// @Route(/test/route)
+// @Description Receiver With Invalid Json
+type ReceiverWithNoComments struct {
+	runtime.GleeceController
+}
+
+// @Query(id, {' Invalid JSON5 })
+func (rc *ReceiverWithNoComments) HasInvalidJson() error {
+	return nil
+}

--- a/test/visitors/controllers/receiver.with.no.comments.go
+++ b/test/visitors/controllers/receiver.with.no.comments.go
@@ -1,0 +1,16 @@
+package visitors_test
+
+import (
+	"github.com/gopher-fleece/runtime"
+)
+
+// @Tag(Receiver With No Comments)
+// @Route(/test/route)
+// @Description Receiver With No Comments
+type ReceiverWithInvalidJson struct {
+	runtime.GleeceController
+}
+
+func (rc *ReceiverWithInvalidJson) NotAnApiMethod() error {
+	return nil
+}

--- a/test/visitors/controllers/receiver.with.no.method.annotation.go
+++ b/test/visitors/controllers/receiver.with.no.method.annotation.go
@@ -1,0 +1,17 @@
+package visitors_test
+
+import (
+	"github.com/gopher-fleece/runtime"
+)
+
+// @Tag(Receiver With No Method Annotation)
+// @Route(/test/route)
+// @Description Receiver With No Method Annotation
+type ReceiverWithNoMethodAnnotation struct {
+	runtime.GleeceController
+}
+
+// @Route(/)
+func (rc *ReceiverWithNoMethodAnnotation) NoMethodAnnotation() error {
+	return nil
+}

--- a/test/visitors/controllers/receiver.with.no.route.annotation.go
+++ b/test/visitors/controllers/receiver.with.no.route.annotation.go
@@ -1,0 +1,17 @@
+package visitors_test
+
+import (
+	"github.com/gopher-fleece/runtime"
+)
+
+// @Tag(Receiver With No Route Annotation)
+// @Route(/test/route)
+// @Description Receiver With No Route Annotation
+type ReceiverWithNoRouteAnnotation struct {
+	runtime.GleeceController
+}
+
+// @Method(GET)
+func (rc *ReceiverWithNoRouteAnnotation) NoRouteAnnotation() error {
+	return nil
+}

--- a/test/visitors/controllers/receiver.with.non.error.return.go
+++ b/test/visitors/controllers/receiver.with.non.error.return.go
@@ -1,0 +1,18 @@
+package visitors_test
+
+import (
+	"github.com/gopher-fleece/runtime"
+)
+
+// @Tag(Receiver With Non Error Return)
+// @Route(/test/route)
+// @Description Receiver With Non Error Return
+type ReceiverWithNonErrorReturn struct {
+	runtime.GleeceController
+}
+
+// @Method(GET)
+// @Route(/)
+func (rc *ReceiverWithNonErrorReturn) NonErrorReturn() bool {
+	return true
+}

--- a/test/visitors/controllers/receiver.with.void.return.go
+++ b/test/visitors/controllers/receiver.with.void.return.go
@@ -1,0 +1,17 @@
+package visitors_test
+
+import (
+	"github.com/gopher-fleece/runtime"
+)
+
+// @Tag(Receiver With Void Return)
+// @Route(/test/route)
+// @Description Receiver With Void Return
+type ReceiverWithVoidReturn struct {
+	runtime.GleeceController
+}
+
+// @Method(GET)
+// @Route(/)
+func (rc *ReceiverWithVoidReturn) VoidReturn() {
+}

--- a/test/visitors/visitor_test.go
+++ b/test/visitors/visitor_test.go
@@ -1,0 +1,66 @@
+package visitors_test
+
+import (
+	"testing"
+
+	"github.com/gopher-fleece/gleece/definitions"
+	"github.com/gopher-fleece/gleece/infrastructure/logger"
+	"github.com/gopher-fleece/gleece/test/utils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Visitor Tests", func() {
+
+	var _ = Context("Route Visitor", func() {
+
+		It("Ignores receivers with no annotations", func() {
+			controllers, _, _ := utils.GetMetadataByRelativeConfigOrFail("./configs/receiver.with.no.comments.json")
+			Expect((controllers[0].Routes)).ToNot(ContainElement(Satisfy(func(route definitions.RouteMetadata) bool {
+				return route.OperationId == "NotAnApiMethod"
+			})))
+		})
+
+		It("Returns a correct error when a receiver annotation has invalid JSON", func() {
+			_, _, _, err := utils.GetMetadataByRelativeConfig("./configs/receiver.with.invalid.json.json")
+			Expect(err).To(MatchError(ContainSubstring("method HasInvalidJson - unexpected end of JSON input")))
+		})
+
+		It("Ignores receivers with no @Method annotation", func() {
+			controllers, _, _ := utils.GetMetadataByRelativeConfigOrFail("./configs/receiver.with.no.method.annotation.json")
+			Expect((controllers[0].Routes)).ToNot(ContainElement(Satisfy(func(route definitions.RouteMetadata) bool {
+				return route.OperationId == "NoMethodAnnotation"
+			})))
+		})
+
+		It("Ignores receivers with no @Route annotation", func() {
+			controllers, _, _ := utils.GetMetadataByRelativeConfigOrFail("./configs/receiver.with.no.route.annotation.json")
+			Expect((controllers[0].Routes)).ToNot(ContainElement(Satisfy(func(route definitions.RouteMetadata) bool {
+				return route.OperationId == "NoRouteAnnotation"
+			})))
+		})
+
+		Context("Return Type Checks", func() {
+			It("Returns a correct error when a receiver returns void", func() {
+				_, _, _, err := utils.GetMetadataByRelativeConfig("./configs/receiver.with.void.return.json")
+				Expect(err).To(MatchError(ContainSubstring(
+					"VoidReturn - expected method to return an error or a value and error tuple but found void",
+				)))
+			})
+
+			It("Returns a correct error when a receiver has one return type that is not a error", func() {
+				_, _, _, err := utils.GetMetadataByRelativeConfig("./configs/receiver.with.non.error.return.json")
+				Expect(err).To(MatchError(ContainSubstring(
+					"NonErrorReturn - return type 'bool' expected to be an error or directly embed it",
+				)))
+			})
+		})
+	})
+
+})
+
+func TestVisitors(t *testing.T) {
+	logger.SetLogLevel(logger.LogLevelNone)
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Visitor Tests")
+}


### PR DESCRIPTION
* Fixed an issue in which recursive expansion was not done for Slice-type parameters.
  Example:
 
    **Units package**
    ```go
    type SimpleStruct struct {
	    FieldA string
	    FieldB int
    }
    
    type StructWithStructSlice struct {
	    SimpleStructSlice []SimpleStruct
    }
    ```
   **Controller**
    ```go
    
    
    // @Method(POST)
    // @Route(/imports-from-other-package)
    // @Body(body)
    func (ec *SanityController) ImportsTypeFromOtherPackage(body []units.StructWithStructSlice) error {
	    return nil
    }
    ```
    
    would generate a model for `StructWithStructSlice` but not for `SimpleStruct`



* Fixed an issue where receivers returning a Universe type could cause a panic instead of  a normal error

* Added test coverage for the routes section of the visitor system

* Updated `gitignore` to properly include all `__debug` files