### PR TITLE
Mark generic objects as empty "object"

### DIFF
--- a/generator/swagen/swagen30/spec_common.go
+++ b/generator/swagen/swagen30/spec_common.go
@@ -18,7 +18,7 @@ func InterfaceToSchemaRef(openapi *openapi3.T, interfaceType string) *openapi3.S
 	openapiType := swagtool.ToOpenApiType(interfaceType)
 	fieldSchemaRef := ToOpenApiSchemaRef(openapiType)
 
-	if openapiType == "object" && !swagtool.IsMapObject(interfaceType) { // For now, ignore map objects, they will be handled later
+	if openapiType == "object" && !swagtool.IsGenericObject(interfaceType) {
 		// Handle other types or complex types as references to other schemas
 		fieldSchemaRef = &openapi3.SchemaRef{
 			Ref: "#/components/schemas/" + interfaceType,

--- a/generator/swagen/swagen31/spec_common31.go
+++ b/generator/swagen/swagen31/spec_common31.go
@@ -33,7 +33,7 @@ func InterfaceToSchemaV3(doc *v3.Document, interfaceType string) *highbase.Schem
 	openapiType := swagtool.ToOpenApiType(interfaceType)
 	fieldSchema := ToOpenApiSchemaV3(openapiType)
 
-	if openapiType == "object" && !swagtool.IsMapObject(interfaceType) { // For now, ignore map objects, they will be handled later
+	if openapiType == "object" && !swagtool.IsGenericObject(interfaceType) {
 		return highbase.CreateSchemaProxyRef("#/components/schemas/" + interfaceType)
 	}
 	if openapiType == "array" {

--- a/generator/swagen/swagtool/spec_helpers.go
+++ b/generator/swagen/swagtool/spec_helpers.go
@@ -164,8 +164,15 @@ func GetJsonNameFromTag(tag string, defaultName string) string {
 	return strings.Split(fullTagValue, ",")[0]
 }
 
-func IsMapObject(typeName string) bool {
-	return strings.HasPrefix(typeName, "map[")
+// IsGenericObject checks if the type should be represented as a generic object wihtout representation in the models collection in OpenAPI specification
+// (e.g. map, any, interface{}, etc.)
+func IsGenericObject(typeName string) bool {
+	switch typeName {
+	case "interface{}", "any", "":
+		return true
+	default:
+		return strings.HasPrefix(typeName, "map[")
+	}
 }
 
 func IsFieldRequired(validationString string) bool {

--- a/generator/swagen/swagtool/spec_helpers_test.go
+++ b/generator/swagen/swagtool/spec_helpers_test.go
@@ -146,23 +146,31 @@ var _ = Describe("Spec Helpers", func() {
 		})
 	})
 
-	Describe("IsMapObject", func() {
+	Describe("IsGenericObject", func() {
 		It("should return true for map types", func() {
-			Expect(IsMapObject("map[string]int")).To(BeTrue())
-			Expect(IsMapObject("map[string]interface{}")).To(BeTrue())
-			Expect(IsMapObject("map[int]string")).To(BeTrue())
+			Expect(IsGenericObject("map[string]int")).To(BeTrue())
+			Expect(IsGenericObject("map[string]interface{}")).To(BeTrue())
+			Expect(IsGenericObject("map[int]string")).To(BeTrue())
 		})
 
-		It("should return false for non-map types", func() {
-			Expect(IsMapObject("string")).To(BeFalse())
-			Expect(IsMapObject("[]string")).To(BeFalse())
-			Expect(IsMapObject("int")).To(BeFalse())
-			Expect(IsMapObject("")).To(BeFalse())
+		It("should return false for non-generic types", func() {
+			Expect(IsGenericObject("string")).To(BeFalse())
+			Expect(IsGenericObject("[]string")).To(BeFalse())
+			Expect(IsGenericObject("int")).To(BeFalse())
+			Expect(IsGenericObject("model")).To(BeFalse())
+			Expect(IsGenericObject("Model")).To(BeFalse())
 		})
 
 		It("should return false for partial map-like strings", func() {
-			Expect(IsMapObject("mapstring]")).To(BeFalse())
-			Expect(IsMapObject("[map]")).To(BeFalse())
+			Expect(IsGenericObject("mapstring]")).To(BeFalse())
+			Expect(IsGenericObject("[map]")).To(BeFalse())
+		})
+
+		It("should return true for generic types", func() {
+			Expect(IsGenericObject("any")).To(BeTrue())
+			Expect(IsGenericObject("interface{}")).To(BeTrue())
+			Expect(IsGenericObject("map[string]any")).To(BeTrue())
+			Expect(IsGenericObject("")).To(BeTrue())
 		})
 	})
 


### PR DESCRIPTION
Set "any", "interface{}", types etc, as  "object" with any properties (aka empty) in the specification